### PR TITLE
Fix path traversal vulnerability in RobotFileSystemManager (Snyk CWE-23)

### DIFF
--- a/robocode.host/src/main/java/net/sf/robocode/host/io/RobotFileSystemManager.java
+++ b/robocode.host/src/main/java/net/sf/robocode/host/io/RobotFileSystemManager.java
@@ -295,7 +295,17 @@ public class RobotFileSystemManager {
 				os = null;
 				try {
 					is = jarFile.getInputStream(jarEntry);
-					os = new FileOutputStream(new File(parent, filename));
+					File targetFile = new File(parent, filename);
+					String canonicalParentPath = parent.getCanonicalPath();
+					String canonicalTargetPath = targetFile.getCanonicalPath();
+
+					if (!canonicalTargetPath.startsWith(canonicalParentPath + File.separator)) {
+						Logger.logError("Blocked potential path traversal: " + filename);
+						continue; // Skip writing this file
+					}
+
+					os = new FileOutputStream(targetFile);
+
 					copyStream(is, os);
 				} finally {
 					FileUtil.cleanupStream(is);


### PR DESCRIPTION
### Summary

This PR addresses a **Path Traversal (Zip-Slip)** vulnerability in the `updateDataFilesFromJar()` method inside `RobotFileSystemManager.java`.  
The issue was flagged by **Snyk (CWE-23)** as a medium severity vulnerability due to unsafe handling of file paths extracted from JAR entries.

---

### 🔧 Changes Made

- Introduced **canonical path validation** to prevent writing files outside the writable directory.
- Added log warning and skipped malicious entries trying to exploit `../` patterns.
- Ensures the extracted files from the JAR stay within the `parent` directory.

---

### 🔍 Before Fix (Vulnerable Code)
```java
os = new FileOutputStream(new File(parent, filename));
